### PR TITLE
The `with-span` macro should tag errors on custom spans 

### DIFF
--- a/src/chisel/trace.clj
+++ b/src/chisel/trace.clj
@@ -28,6 +28,9 @@
      (try
        (binding [*span* span#]
          ~@body)
+       (catch Throwable ex#
+         (plog/tag-span "error" true)
+         (throw ex#))
        (finally
          (plog/finish-span span#)))))
 


### PR DESCRIPTION
# One-line summary
Allow the with-span macro to tag spans as errors on Exceptions.

## Description
Exceptions are thrown at any levels and handled by the global Exception handling interceptor.
This would tag the server and client spans as errors, but ignore all custom spans in-between.
Every custom span should also be tagged with an error, if an Exception was thrown.

## Types of Changes
- New feature (non-breaking change which adds functionality)


