### PR TITLE
tag-span needs the span as a first argument

### DIFF
--- a/src/chisel/trace.clj
+++ b/src/chisel/trace.clj
@@ -29,7 +29,7 @@
        (binding [*span* span#]
          ~@body)
        (catch Throwable ex#
-         (plog/tag-span "error" true)
+         (plog/tag-span span# "error" true)
          (throw ex#))
        (finally
          (plog/finish-span span#)))))


### PR DESCRIPTION
# One-line summary
The existing with-span macro is failing with ```IllegalArgumentException No implementation of method: :kv-reduce of protocol: #'clojure.core.protocols/IKVReduce found for class: java.lang.Boolean  clojure.core/-cache-protocol-fn (core_deftype.clj:583)```

## Description
The pedestal.log's tag-span requires the actual span as the first argument.

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)
