### PR TITLE
Improve opentracing logs

### DIFF
--- a/src/chisel/http_client.clj
+++ b/src/chisel/http_client.clj
@@ -67,10 +67,10 @@
       (binding [correlation-ctx/*ctx* captured-ctx]         ; and restore it in callback
         (let [msg (or (.getMessage exception) "none")]
           (-> span
-              (plog/log-span
+              (trace/log-span
                 :service service-name
                 :route route-name)
-              (plog/log-span exception)
+              (trace/log-span exception)
               (plog/tag-span "error" true)
               (plog/finish-span))
           (log/error :msg "Remote call failed"
@@ -154,7 +154,7 @@
       (do
         (mark-meter [metric-prefix route-name "opened"])
         (-> span
-            (plog/log-span
+            (trace/log-span
               :message "Circuit Breaker opened"
               :service service-name
               :route route-name


### PR DESCRIPTION
# One-line summary
Small fixes on the open tracing integration.

## Description
- make sure there are no NPEs during calls to the OpenTracing Java library
- only server-side errors (5xx) are tagged with an error on the server span, while client-side errors (4xx) are considered fine

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements
